### PR TITLE
feat: create UnpublishedMatches and MatchPublish

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,8 @@ import AddTitle from './pages/admin/AddTitle'
 import AddStadium from './pages/admin/AddStadium'
 import AddTerm from './pages/admin/AddTerm'
 import AddPrivacy from './pages/admin/AddPrivacy'
-import UnpublishedPosts from './pages/admin/UnpublishedPosts';
+import PreEditedMatches from './pages/admin/PreEditedMatches';
+import UnpublishedMatches from './pages/admin/UnpublishedMatches';
 import ContactIndex from './pages/admin/ContactIndex';
 import UserEdit from './pages/UserEdit';
 import PasswordEdit from './pages/PasswordEdit';
@@ -69,7 +70,8 @@ const App = () => {
             <>
               <Route path="/admin/main" component={AdminMain}/>
               <Route path="/admin/match/new" component={MatchNew}/>
-              <Route path="/admin/match/edit" component={UnpublishedPosts}/>
+              <Route path="/admin/match/edit" component={PreEditedMatches}/>
+              <Route path="/admin/match/publish" component={UnpublishedMatches}/>
               <Route path="/admin/add_team" component={AddTeam}/>
               <Route path="/admin/add_club" component={AddClub}/>
               <Route path="/admin/add_title" component={AddTitle}/>

--- a/src/pages/admin/AdminMain.js
+++ b/src/pages/admin/AdminMain.js
@@ -34,6 +34,9 @@ const AdminMain = () => {
           <Nav.Link>試合情報の新規作成</Nav.Link>
         </LinkContainer>
         <LinkContainer to="/admin/match/edit">
+          <Nav.Link>試合情報の編集</Nav.Link>
+        </LinkContainer>
+        <LinkContainer to="/admin/match/publish">
           <Nav.Link>試合情報の投稿</Nav.Link>
         </LinkContainer>
         <LinkContainer to="/admin/add_team">

--- a/src/pages/admin/MatchEdit.js
+++ b/src/pages/admin/MatchEdit.js
@@ -146,7 +146,7 @@ const MatchEdit = ({match,filterMatches,height}) => {
         </Col>
       </Row>
       <Card.Footer>
-        <Button onClick={publishMatch}>試合情報投稿</Button>
+        <Button onClick={publishMatch}>試合情報更新</Button>
       </Card.Footer>
     </Card>
   )

--- a/src/pages/admin/MatchPublish.js
+++ b/src/pages/admin/MatchPublish.js
@@ -1,0 +1,134 @@
+import React, {useState} from 'react';
+import { useHistory } from 'react-router-dom';
+import axios from 'axios';
+import {Row,Col,Form,Button,Card} from 'react-bootstrap';
+import {ReactComponent as Emblem} from "../../images/emblem.svg"
+
+const MatchPublish = ({match,filterMatches,height}) => {
+  const history = useHistory();
+
+  const publishMatch = () => {
+    filterMatches(match.id);
+    axios.patch(`${process.env.REACT_APP_API_ENDPOINT}/matches/publish/${match.id}`,
+      {},
+      {
+      headers: {
+        uid: localStorage.getItem('uid'),
+        'access-token': localStorage.getItem('access-token'),
+        client: localStorage.getItem('client')
+      }
+    }).then((response) => {
+      if(response.status === 401) {
+        history.push('/sign-in');
+      } else {
+        console.log(response);
+      }
+    }).catch((error) => {
+      console.log(error);
+    })
+  }
+
+  return (
+    <Card style={{height: `${height}px`}}>
+      <Card.Header className="text-center" style={{backgroundColor: '#f8f9fa', color: 'black'}}>
+        <Row>
+          <Col xs={3} className="d-flex justify-content-center align-items-center"></Col>
+          <Col xs={6} className="d-flex justify-content-center align-items-center small">{match.date_time}</Col>
+          <Col xs={3} className="d-flex justify-content-center align-items-center small">{match.title}</Col>
+        </Row>
+      </Card.Header>
+      <Card.Body className="text-center">
+        <Card.Title>
+          <Row className="justify-content-center">
+            <Col className="align-items-end">
+              <Emblem className="me-1" height="25" width="25" fill={`${match.home_team.color_code}`} style={{verticalAlign: "middle"}} stroke="gray" strokeWidth="10"/>
+              <span style={{verticalAlign: "middle"}}>{match.home_team.name}</span>
+            </Col>
+            <Col className="align-items-end">
+              <Emblem className="me-1" height="25" width="25" fill={`${match.away_team.color_code}`} style={{verticalAlign: "middle"}} stroke="gray" strokeWidth="10"/>
+              <span style={{verticalAlign: "middle"}}>{match.away_team.name}</span>
+            </Col>
+          </Row>
+        </Card.Title>
+      <Row>
+        <Col xs={3} ></Col>
+        <Col xs={6} className="h1">
+          <Row>
+            <Col xs={5} className="d-flex justify-content-end align-items-center" style={{verticalAlign: "middle"}}>{String(match.home_score)}</Col>
+            <Col xs={2} className="d-flex justify-content-center align-items-center" style={{verticalAlign: "middle"}}>-</Col>
+            <Col xs={5} className="d-flex justify-content-start align-items-center" style={{verticalAlign: "middle"}}>{String(match.away_score)}</Col>
+          </Row>
+        </Col>
+        <Col xs={3}/>
+      </Row>
+      { (match.home_team.goal_players) && (match.home_team.goal_players.length > 0 || match.away_team.goal_players.length > 0) && (
+        <>
+          <div className="mx-5">
+            <hr />
+          </div>
+          <div className="text-center h5 text-secondary">
+            得点者
+          </div>
+          <Row className="text-secondary" style={{fontSize: "0.75rem"}}>
+            <Col className="text-start px-3" style={{height: "70px", overflow:"auto"}}>
+              {match.home_team.goal_players && match.home_team.goal_players.map((player, index) => (
+                <div key={index}>
+                  <span>{player.name} ({player.time}')</span>
+                </div>
+              ))}
+            </Col>
+            <Col className="text-start ps-1" style={{height: "70px", overflow:"auto"}}>
+              {match.away_team.goal_players && match.away_team.goal_players.map((player, index) => (
+                <div key={index}>
+                  <span>{player.name} ({player.time}')</span>
+                </div>
+              ))}
+            </Col>
+          </Row>
+        </>
+      )}
+      {(match.home_team.red_players) && (match.home_team.red_players.length > 0 || match.away_team.red_players.length > 0) && (
+        <>
+          <div className="mx-5">
+            <hr />
+          </div>
+          <div className="text-center h5 text-secondary mt-3">
+            退場者
+          </div>
+          <Row className="text-secondary" style={{fontSize: "0.75rem"}}>
+            <Col className="text-start px-3" style={{height: "30px", overflow:"auto"}}>
+              {match.home_team.red_players && match.home_team.red_players.map((player, index) => (
+                <div key={index}>
+                  <span>{player.name} ({player.time}')</span>
+                </div>
+              ))}
+            </Col>
+            <Col className="text-start pe-1" style={{height: "30px", overflow:"auto"}}>
+              {match.away_team.red_players && match.away_team.red_players.map((player, index) => (
+                <div key={index}>
+                  <span>{player.name} ({player.time}')</span>
+                </div>
+              ))}
+            </Col>
+          </Row>
+        </>
+      )}
+      <Row className="text-end">
+        <Col className="mx-5">
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <span className="text-muted small">＠ {match.stadium_name}</span>
+        </Col>
+        <Col xs={12}>
+          <span className="text-muted small">観客数：{match.mobilization}人</span>
+        </Col>
+      </Row>
+      </Card.Body>
+        <Card.Footer>
+          <Button onClick={publishMatch}>試合情報投稿</Button>
+        </Card.Footer>
+    </Card>
+  )
+}
+export default MatchPublish;

--- a/src/pages/admin/PreEditedMatches.js
+++ b/src/pages/admin/PreEditedMatches.js
@@ -6,14 +6,14 @@ import MatchEdit from './MatchEdit';
 import Layout from '../../components/Layout';
 import {TransitionMotion,spring} from 'react-motion'
 
-const UnpublishedPosts = () => {
+const PreEditedMatches = () => {
 
   const [matches,setMatches] = useState([]);
 
   const history = useHistory();
 
   useEffect(() => {
-    axios.get(`${process.env.REACT_APP_API_ENDPOINT}/matches/publish`,{
+    axios.get(`${process.env.REACT_APP_API_ENDPOINT}/matches/edit`,{
       headers: {
         uid: localStorage.getItem('uid'),
         'access-token': localStorage.getItem('access-token'),
@@ -72,4 +72,4 @@ const UnpublishedPosts = () => {
   );
 }
 
-export default UnpublishedPosts;
+export default PreEditedMatches;

--- a/src/pages/admin/UnpublishedMatches.js
+++ b/src/pages/admin/UnpublishedMatches.js
@@ -1,0 +1,72 @@
+import React,{useState,useEffect} from 'react';
+import { useHistory } from 'react-router-dom';
+import axios from 'axios'
+import { Container, Row, Col} from 'react-bootstrap'
+import MatchPublish from './MatchPublish';
+import Layout from '../../components/Layout';
+import {TransitionMotion,spring} from 'react-motion'
+
+const PreEditedMatches = () => {
+
+  const [matches,setMatches] = useState([]);
+
+  const history = useHistory();
+
+  useEffect(() => {
+    axios.get(`${process.env.REACT_APP_API_ENDPOINT}/matches/publish`,{
+      headers: {
+        uid: localStorage.getItem('uid'),
+        'access-token': localStorage.getItem('access-token'),
+        client: localStorage.getItem('client')
+      }
+    }).then( response => {
+      setMatches(response.data);
+    }).catch((error) => {
+      history.push('/sign-in');
+      console.log(error);
+    })
+  },[history])
+
+  const willLeave = () => {
+    return {height: spring(0,{stiffness:240,dumping:30})}
+  }
+
+  const filterMatches = (matchId) => {
+    setMatches((matches.filter(match => match.id !== matchId)))
+  }
+
+  return (
+    <Layout>
+      <Container>
+        <Row xs={1} md={1} className="g-2">
+          <TransitionMotion
+            willLeave={willLeave}
+            styles={
+              matches.map((match) => (
+                {
+                  key: String(match.id),
+                  data: match,
+                  style: {height: match.height}
+                }
+              ))
+            }
+          >
+            {interpolatingStyles =>
+              <>
+              {interpolatingStyles.map(interpolatingStyle => {
+                return (
+                  <Col key={interpolatingStyle.key}>
+                    <MatchPublish match={interpolatingStyle.data} filterMatches={filterMatches} height={interpolatingStyle.style.height}/>
+                  </Col>
+                )
+              })}
+              </>
+            }
+          </TransitionMotion>
+        </Row>
+      </Container>
+  </Layout>
+  );
+}
+
+export default PreEditedMatches;


### PR DESCRIPTION
Matchを発行する際、編集と発行のステップを分割することで試合情報をより正確に発行できるようにしました。
各ファイルの対応関係は以下のとおりです。

- UnpublishedMatches
-- Matchの編集が済んでおり、publishしてよいか確認をするためのページ用コンポーネント。
-- 中に`MatchPublish`コンポーネントを当該Matchの個数だけ含んでいる。

- PreEditedMatches
-- Matchの編集を行うためのページ用コンポーネント。(もともとあったものをリネームした。)
-- 中に`MatchEdit`コンポーネントを当該Matchの個数だけ含んでいる。 