### PR TITLE
Match発行フローの改善(frontend)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import Contact from './pages/Contact';
 
 // 管理者用 書く場所が正しいかは不明なので要相談(20210626浅)
 import AdminMain from './pages/admin/AdminMain'
+import OnPublishedMatches from './pages/admin/OnPublishedMatches'
 import MatchNew from './pages/admin/MatchNew'
 import AddTeam from './pages/admin/AddTeam'
 import AddClub from './pages/admin/AddClub'
@@ -72,6 +73,7 @@ const App = () => {
               <Route path="/admin/match/new" component={MatchNew}/>
               <Route path="/admin/match/edit" component={PreEditedMatches}/>
               <Route path="/admin/match/publish" component={UnpublishedMatches}/>
+              <Route path="/admin/match/on-published-index" component={OnPublishedMatches}/>
               <Route path="/admin/add_team" component={AddTeam}/>
               <Route path="/admin/add_club" component={AddClub}/>
               <Route path="/admin/add_title" component={AddTitle}/>

--- a/src/pages/admin/AdminMain.js
+++ b/src/pages/admin/AdminMain.js
@@ -39,6 +39,9 @@ const AdminMain = () => {
         <LinkContainer to="/admin/match/publish">
           <Nav.Link>試合情報の投稿</Nav.Link>
         </LinkContainer>
+        <LinkContainer to="/admin/match/on-published-index">
+          <Nav.Link>発行済み試合情報一覧</Nav.Link>
+        </LinkContainer>
         <LinkContainer to="/admin/add_team">
           <Nav.Link>Teamの追加</Nav.Link>
         </LinkContainer>

--- a/src/pages/admin/MatchEdit.js
+++ b/src/pages/admin/MatchEdit.js
@@ -82,7 +82,26 @@ const MatchEdit = ({match,filterMatches,height}) => {
       }
     }).catch((error) => {
       console.log(error);
-      // history.push('/sign-in');
+    })
+  }
+
+  const deleteMatch = () => {
+    filterMatches(match.id);
+    axios.delete(`${process.env.REACT_APP_API_ENDPOINT}/matches/${match.id}`,
+      {
+      headers: {
+        uid: localStorage.getItem('uid'),
+        'access-token': localStorage.getItem('access-token'),
+        client: localStorage.getItem('client')
+      }
+    }).then((response) => {
+      if(response.status === 401) {
+        history.push('/sign-in');
+      } else {
+        console.log(response);
+      }
+    }).catch((error) => {
+      console.log(error);
     })
   }
 
@@ -165,7 +184,14 @@ const MatchEdit = ({match,filterMatches,height}) => {
         </Col>
       </Row>
       <Card.Footer>
-        <Button onClick={publishMatch}>試合情報更新</Button>
+        <Row>
+          <Col>
+            <Button onClick={publishMatch}>試合情報更新</Button>
+          </Col>
+          <Col className="text-end">
+            <Button variant="danger" className="text-end" onClick={deleteMatch}>試合情報削除</Button>
+          </Col>
+        </Row>
       </Card.Footer>
     </Card>
   )

--- a/src/pages/admin/MatchPublish.js
+++ b/src/pages/admin/MatchPublish.js
@@ -28,6 +28,27 @@ const MatchPublish = ({match,filterMatches,height}) => {
     })
   }
 
+  const unpublishMatch = () => {
+    filterMatches(match.id);
+    axios.patch(`${process.env.REACT_APP_API_ENDPOINT}/matches/unpublish/${match.id}`,
+      {},
+      {
+      headers: {
+        uid: localStorage.getItem('uid'),
+        'access-token': localStorage.getItem('access-token'),
+        client: localStorage.getItem('client')
+      }
+    }).then((response) => {
+      if(response.status === 401) {
+        history.push('/sign-in');
+      } else {
+        console.log(response);
+      }
+    }).catch((error) => {
+      console.log(error);
+    })
+  }
+
   return (
     <Card style={{height: `${height}px`}}>
       <Card.Header className="text-center" style={{backgroundColor: '#f8f9fa', color: 'black'}}>
@@ -126,7 +147,14 @@ const MatchPublish = ({match,filterMatches,height}) => {
       </Row>
       </Card.Body>
         <Card.Footer>
-          <Button onClick={publishMatch}>試合情報投稿</Button>
+          <Row>
+            <Col>
+              <Button onClick={publishMatch}>試合情報投稿</Button>
+            </Col>
+            <Col className="text-end">
+              <Button variant="danger" className="text-end" onClick={unpublishMatch}>試合情報差し戻し</Button>
+            </Col>
+          </Row>
         </Card.Footer>
     </Card>
   )

--- a/src/pages/admin/OnPublishedMatch.js
+++ b/src/pages/admin/OnPublishedMatch.js
@@ -1,0 +1,140 @@
+import React, {useState} from 'react';
+import { useHistory } from 'react-router-dom';
+import axios from 'axios';
+import {Row,Col,Button,Card} from 'react-bootstrap';
+import {ReactComponent as Emblem} from "../../images/emblem.svg"
+
+const OnPublishedMatch = ({match}) => {
+
+  const [isSubmitDisable,setIsSubmitDisable] = useState(false);
+  const [submitButtonLabel, setSubmitButtonLabel] = useState('試合情報差し戻し');
+  const history = useHistory();
+
+  const unpublishMatch = () => {
+    axios.patch(`${process.env.REACT_APP_API_ENDPOINT}/matches/unpublish/${match.id}`,
+      {},
+      {
+      headers: {
+        uid: localStorage.getItem('uid'),
+        'access-token': localStorage.getItem('access-token'),
+        client: localStorage.getItem('client')
+      }
+    }).then((response) => {
+      if(response.status === 401) {
+        history.push('/sign-in');
+      } else {
+        setIsSubmitDisable(true);
+        setSubmitButtonLabel('この試合は差し戻されました。');
+        console.log(response);
+      }
+    }).catch((error) => {
+      console.log(error);
+    })
+  }
+
+  return (
+    <Card style={{height: `${match.height}px`}}>
+      <Card.Header className="text-center" style={{backgroundColor: '#f8f9fa', color: 'black'}}>
+        <Row>
+          <Col xs={3} className="d-flex justify-content-center align-items-center"></Col>
+          <Col xs={6} className="d-flex justify-content-center align-items-center small">{match.date_time}</Col>
+          <Col xs={3} className="d-flex justify-content-center align-items-center small">{match.title}</Col>
+        </Row>
+      </Card.Header>
+      <Card.Body className="text-center">
+        <Card.Title>
+          <Row className="justify-content-center">
+            <Col className="align-items-end">
+              <Emblem className="me-1" height="25" width="25" fill={`${match.home_team.color_code}`} style={{verticalAlign: "middle"}} stroke="gray" strokeWidth="10"/>
+              <span style={{verticalAlign: "middle"}}>{match.home_team.name}</span>
+            </Col>
+            <Col className="align-items-end">
+              <Emblem className="me-1" height="25" width="25" fill={`${match.away_team.color_code}`} style={{verticalAlign: "middle"}} stroke="gray" strokeWidth="10"/>
+              <span style={{verticalAlign: "middle"}}>{match.away_team.name}</span>
+            </Col>
+          </Row>
+        </Card.Title>
+      <Row>
+        <Col xs={3} ></Col>
+        <Col xs={6} className="h1">
+          <Row>
+            <Col xs={5} className="d-flex justify-content-end align-items-center" style={{verticalAlign: "middle"}}>{String(match.home_score)}</Col>
+            <Col xs={2} className="d-flex justify-content-center align-items-center" style={{verticalAlign: "middle"}}>-</Col>
+            <Col xs={5} className="d-flex justify-content-start align-items-center" style={{verticalAlign: "middle"}}>{String(match.away_score)}</Col>
+          </Row>
+        </Col>
+        <Col xs={3}/>
+      </Row>
+      { (match.home_team.goal_players) && (match.home_team.goal_players.length > 0 || match.away_team.goal_players.length > 0) && (
+        <>
+          <div className="mx-5">
+            <hr />
+          </div>
+          <div className="text-center h5 text-secondary">
+            得点者
+          </div>
+          <Row className="text-secondary" style={{fontSize: "0.75rem"}}>
+            <Col className="text-start px-3" style={{height: "70px", overflow:"auto"}}>
+              {match.home_team.goal_players && match.home_team.goal_players.map((player, index) => (
+                <div key={index}>
+                  <span>{player.name} ({player.time}')</span>
+                </div>
+              ))}
+            </Col>
+            <Col className="text-start ps-1" style={{height: "70px", overflow:"auto"}}>
+              {match.away_team.goal_players && match.away_team.goal_players.map((player, index) => (
+                <div key={index}>
+                  <span>{player.name} ({player.time}')</span>
+                </div>
+              ))}
+            </Col>
+          </Row>
+        </>
+      )}
+      {(match.home_team.red_players) && (match.home_team.red_players.length > 0 || match.away_team.red_players.length > 0) && (
+        <>
+          <div className="mx-5">
+            <hr />
+          </div>
+          <div className="text-center h5 text-secondary mt-3">
+            退場者
+          </div>
+          <Row className="text-secondary" style={{fontSize: "0.75rem"}}>
+            <Col className="text-start px-3" style={{height: "30px", overflow:"auto"}}>
+              {match.home_team.red_players && match.home_team.red_players.map((player, index) => (
+                <div key={index}>
+                  <span>{player.name} ({player.time}')</span>
+                </div>
+              ))}
+            </Col>
+            <Col className="text-start pe-1" style={{height: "30px", overflow:"auto"}}>
+              {match.away_team.red_players && match.away_team.red_players.map((player, index) => (
+                <div key={index}>
+                  <span>{player.name} ({player.time}')</span>
+                </div>
+              ))}
+            </Col>
+          </Row>
+        </>
+      )}
+      <Row className="text-end">
+        <Col className="mx-5">
+          <hr />
+        </Col>
+        <Col xs={12}>
+          <span className="text-muted small">＠ {match.stadium_name}</span>
+        </Col>
+        <Col xs={12}>
+          <span className="text-muted small">観客数：{match.mobilization}人</span>
+        </Col>
+      </Row>
+      </Card.Body>
+        <Card.Footer>
+          <div className="text-end">
+            <Button variant="danger" className="text-end" onClick={unpublishMatch} disabled={isSubmitDisable}>{submitButtonLabel}</Button>
+          </div>
+        </Card.Footer>
+    </Card>
+  )
+}
+export default OnPublishedMatch;

--- a/src/pages/admin/OnPublishedMatches.js
+++ b/src/pages/admin/OnPublishedMatches.js
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+import { HelmetProvider } from 'react-helmet-async';
+import Head from '../../components/Head';
+import Layout from '../../components/Layout';
+import axios from 'axios';
+import InfiniteScroll from 'react-infinite-scroller'
+import { Container, Spinner } from 'react-bootstrap';
+import OnPublishedMatch from './OnPublishedMatch';
+import ReturnTopButton from '../../components/ReturnTopButton';
+
+const OnPublishedMatches = () => {
+
+  const [matches, setMatches] = useState([]);
+  const [hasMore,setHasMore] = useState(true);
+
+  const loadMore = async (page) => {
+    const data = await axios.get(`${process.env.REACT_APP_API_ENDPOINT}/matches/admin/on-published-index?page=${page}`, {
+      headers: {
+        uid: localStorage.getItem('uid'),
+        'access-token': localStorage.getItem('access-token'),
+        client: localStorage.getItem('client')
+      }
+    }).then((response) => {
+      return response.data;
+    })
+    if (data.length < 1) {
+      setHasMore(false);
+      return;
+    }
+    setMatches([...matches,...data]);
+  }
+
+  const loader = <Spinner key={0} animation="border" variant="secondary" />
+
+  useEffect(() => {
+    axios.get(`${process.env.REACT_APP_API_ENDPOINT}/matches/admin/on-published-index`, {
+      headers: {
+        uid: localStorage.getItem('uid'),
+        'access-token': localStorage.getItem('access-token'),
+        client: localStorage.getItem('client')
+      }
+    }).then((response) => {
+      return response.data;
+    }).then((data) => {
+      setMatches(data);
+    })
+  },[]);
+
+  return (
+    <HelmetProvider>
+      <Layout>
+        <Head title="観戦記録の作成" />
+        <Container>
+          <div className="mt-4">
+            <InfiniteScroll loadMore={loadMore} hasMore={hasMore} loader={loader} className="text-center">
+              {matches.map((match) => (
+                <OnPublishedMatch match={match}/>
+              )
+              )}
+            </InfiniteScroll>
+          </div>
+        </Container>
+      </Layout>
+      <ReturnTopButton />
+    </HelmetProvider>
+  )
+}
+
+export default OnPublishedMatches;


### PR DESCRIPTION
## 概要
adminでのMatchの投稿フローをより安全なものにするためにAPI側でmatchesテーブルにpublish_statusカラムを追加し、Matchの状態管理の方法を変更しました。(ref footlog-api PR [#22](https://github.com/dustium162/footlog-api/pull/22))

この変更に伴い、フロントのadminページに以下の変更を加えました。API側の変更についても付記します。
- 得点情報等の入力ページに「試合情報削除ボタン」を設置。
  - 当該Matchに1つ以上のPostが存在する場合は削除しないようにしました。(その旨を伝えるアラート等は未実装。)
- 試合情報発行ページに「試合情報差し戻しボタン」を設置。
  - `publish_status`を`not_held`に変更する。
- 発行済試合情報一覧ページを作成。
  - 試合情報の閲覧と「試合情報差し戻し」が可能。(差し戻し機能は発行ページと同じ。)

### 補足(api側のPRにも同様の補足をします。)
試合情報を差し戻したタイミングでは、`GoalPlayer`や`RedPlayer`は削除せず、`MatchesController#update`の中で削除を行うように実装しました。
これは将来的に「得点情報等の入力ページ」に差し戻されたMatchがある場合、その情報を表示させたいと考えているためです。これは別PRで対応したいと思っています。

### 補足2
このPRはAPIの変更に依存するため、マージのタイミングは相談しましょう。