### PR TITLE
管理者機能「スタジアムとタイトルの追加」のバグ修正

### DIFF
--- a/src/pages/admin/AddStadium.js
+++ b/src/pages/admin/AddStadium.js
@@ -68,12 +68,12 @@ const AddStadium = () => {
         is_new_stadium_type: isNewStadiumType
       },
       {
-        header: {
+        headers: {
           uid: localStorage.getItem('uid'),
           'access-token': localStorage.getItem('access-token'),
           client: localStorage.getItem('client')
         }
-      }
+      },
     ).then((response) => {
       if(response.status === 204){
         history.push('/admin/main');

--- a/src/pages/admin/AddStadium.js
+++ b/src/pages/admin/AddStadium.js
@@ -50,8 +50,8 @@ const AddStadium = () => {
   }
 
   const handleIsNewStadiumTypeChange = (e) => {
-    setIsNewStadiumType(e.target.value);
-    setIsSubmitDisable(!((stadiumTypeId && name) || (name && isNewStadiumType)));
+    setIsNewStadiumType(!isNewStadiumType);
+    setIsSubmitDisable(!((stadiumTypeId && name) || (name && !isNewStadiumType)));
   }
 
   const handleSubmit = (e) =>{

--- a/src/pages/admin/AddTitle.js
+++ b/src/pages/admin/AddTitle.js
@@ -51,8 +51,8 @@ const AddTitle = () => {
   }
 
   const handleIsNewTitleTypeChange = (e) => {
-    setIsNewTitleType(e && e.target ? e.target.value : '');
-    setIsSubmitDisable(!((titleTypeId && name) || (name && isNewTitleType)));
+    setIsNewTitleType(!isNewTitleType);
+    setIsSubmitDisable(!((titleTypeId && name) || (name && !isNewTitleType)));
   }
 
   const handleSubmit = (e) =>{


### PR DESCRIPTION
# 概要
以下の２点を修正し、新規にスタジアムとタイトルの追加する機能のバグ修正をおこないました。
- リクエストヘッダーの設定修正
- 新規か否かのパラメータ（`isNewStadiumType`と`isNewTitleType`）を文字列から真偽値に修正

あわせてapiリポジトリの「パラメータ値の確認方法を修正」のプルリクを作成しますので、確認をお願いします。